### PR TITLE
Exit if kernel panic happened

### DIFF
--- a/qemu.sh
+++ b/qemu.sh
@@ -23,7 +23,7 @@ fi
 exec qemu-system-x86_64 \
   -no-reboot \
   -kernel "$KERNEL" \
-  -append "root=/dev/sda rw console=ttyS0 $APPEND" \
+  -append "root=/dev/sda rw console=ttyS0 panic=1 $APPEND" \
   -display none -serial stdio \
   $KVM \
   -m "$MEM" \


### PR DESCRIPTION
This is for issue #8 
Basically it tells the guest OS to reboot in 1 second when kernel panic happened.
Combined with `qemu` -no-reboot` option, the guest VM and docker container will closed immediately.